### PR TITLE
Documentation update -> pip installation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -9,19 +9,14 @@ Getting started
 Installation
 ------------
 
-To install, you first need to clone the directory from github::
+To install this package, it is possible to use pip::
 
-    git clone https://github.com/telegraphic/fits2hdf
-
-and then run::
-
-    python setup.py install
+    pip install git+https://github.com/telegraphic/fits2hdf.git
     
 from the command line. You'll need 
 `astropy <http://www.astropy.org/>`_ and `h5py <http://www.h5py.org/>`_ to be installed. If you want to
 use `bitshuffle <https://github.com/kiyo-masui/bitshuffle>`_ compression (good for radio astronomy data), you'll need to install that too.
 
-Installation through ``pip`` will likely be added in the future.
 
 Command line usage
 ------------------

--- a/pip-requirements
+++ b/pip-requirements
@@ -3,4 +3,5 @@ astropy
 colorterm
 colorama
 h5py
+six
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = '1.1.1'
+version = '1.1.2'
 
 # create entry points
 # see http://astropy.readthedocs.org/en/latest/development/scripts.html
@@ -31,7 +31,7 @@ setup(name='fits2hdf',
       description='FITS to HDF5 conversion utility',
       long_description=long_description,
       long_description_content_type='text/markdown',
-      install_requires=['h5py', 'astropy', 'colorama'],
+      install_requires=['h5py', 'astropy', 'colorama', 'six'],
       url='http://github.com/telegraphic/fits2hdf',
       author='Danny Price',
       author_email='dancpr@berkeley.edu',


### PR DESCRIPTION
As of later version of python, six is not always installed by default. For this reason, I have added it to the setup file requirements.  
It is now also possible to install the package directly without cloning the repository using pip. 
I have modified the documentation to notify this possibility, since it was already stated that this package might become available on pip at some point.

Thank you for the great software, I hope this small contribution is appreciated!